### PR TITLE
Add LiteLLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Instructions for other popular providers:
 - [Together AI](https://litellm.vercel.app/docs/providers/togetherai#api-keys)
 - [Anyscale Endpoints](https://litellm.vercel.app/docs/providers/anyscale#api-key)
 
-For other model providers, view the instructions [here](https://litellm.vercel.app/docs/providers). 
+For other model providers, find the instructions [here](https://litellm.vercel.app/docs/providers). 
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -89,15 +89,14 @@ python -m examples.router_chat --router mf --threshold 0.116
 
 By default, GPT-4 and Mixtral 8x7B are used as the model pair for serving. To modify the model pair used, set them using the `--strong-model` and `--weak-model` flags. However, regardless of the model pair, an `OPENAI_API_KEY` is required for generating embeddings.
 
-We leverage [LiteLLM](https://github.com/BerriAI/litellm) to support chat completions from a wide-range of open-source and closed models. In general, you need a setup an API key and point to the provider with the appropriate model name using the `--strong-model` or `--weak-model` flag.
+We leverage [LiteLLM](https://github.com/BerriAI/litellm) to support chat completions from a wide-range of open-source and closed models. In general, you need a setup an API key and point to the provider with the appropriate model name using the `--strong-model` or `--weak-model` flag. Alternatively, you can also use **any OpenAI-compatible endpoint** by prefixing the model name with `openai/` using the `--alt-base-url` and `--alt-api-key` flags to point to the server.
 
-Alternatively, you can also use **any OpenAI-compatible endpoint** by prefixing the model name with `openai/` using the `--alt-base-url` and `--alt-api-key` flags to point to the server.
+See [Routing to Local Models](examples/routing_to_local_models.md) for a walkthrough of routing to local models using Ollama.
 
-Instructions for for popular providers:
+Instructions for other popular providers:
 - [Anthropic](https://litellm.vercel.app/docs/providers/anthropic#api-keys)
 - [Gemini - Google AI Studio](https://litellm.vercel.app/docs/providers/gemini#sample-usage)
 - [Amazon Bedrock](https://litellm.vercel.app/docs/providers/bedrock#required-environment-variables)
-- [Ollama](https://litellm.vercel.app/docs/providers/togetherai#api-keys)
 - [Together AI](https://litellm.vercel.app/docs/providers/togetherai#api-keys)
 - [Anyscale Endpoints](https://litellm.vercel.app/docs/providers/anyscale#api-key)
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ Let's walkthrough setting up a RouteLLM server and pointing our existing OpenAI 
 1. First, launch the RouteLLM server with the `mf` router:
 ```
 > export OPENAI_API_KEY=sk-XXXXXX
-> python -m routellm.openai_server --routers mf --alt-base-url https://api.endpoints.anyscale.com/v1 --alt-api-key ANYSCALE_API_KEY --config config.example.yaml
+> export ANYSCALE_API_KEY=esecret_XXXXXX
+> python -m routellm.openai_server --routers mf --weak-model anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1 ---config config.example.yaml
 INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:6060 (Press CTRL+C to quit)
 ```
-The server is now listening on `http://0.0.0.0:6060`. By default, the router will route between GPT-4 and Mixtral 8x7B, so you'll need to configure your API keys for OpenAI and a model provider for Mixtral 8x7B beforehand (we use Anyscale above).
+The server is now listening on `http://0.0.0.0:6060`. By default, the router will route between GPT-4 and Mixtral 8x7B, so you'll need to configure your API keys for OpenAI and a model provider for Mixtral 8x7B beforehand (we use Anyscale by setting the API key and pointing our weak model to it above).
 
 You can also route between a different model pair by specifying the `--strong-model` and `--weak-model` flags (see [Model Support](#model-support) and [Routing to Local Models](examples/routing_to_local_models.md)).
 
@@ -86,18 +87,21 @@ python -m examples.router_chat --router mf --threshold 0.116
 
 ### Model Support
 
-By default, GPT-4 and Mixtral are used as the model pair for serving. To modify the model pair used, set them using the `--strong-model` and `--weak-model` flags. However, regardless of the model pair, an `OPENAI_API_KEY` is required for generating embeddings.
+By default, GPT-4 and Mixtral 8x7B are used as the model pair for serving. To modify the model pair used, set them using the `--strong-model` and `--weak-model` flags. However, regardless of the model pair, an `OPENAI_API_KEY` is required for generating embeddings.
 
-The server will route all OpenAI model to the OpenAI server. For other models, RouteLLM supports any provider that has an OpenAI-compatible interface, which includes a range of open-source and closed models running locally or in the cloud. To configure this, set the `--alt-base-url` and `--alt-api-key` flags to point to your endpoint.
+We leverage [LiteLLM](https://github.com/BerriAI/litellm) to support chat completions from a wide-range of open-source and closed models. In general, you need a setup an API key and point to the provider with the appropriate model name using the `--strong-model` or `--weak-model` flag.
 
-Instructions for setting up an OpenAI-compatible server for popular providers:
-- [Vertex AI Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library)
-- [Amazon Bedrock](https://github.com/aws-samples/bedrock-access-gateway)
-- [Ollama](https://github.com/ollama/ollama/blob/main/docs/openai.md)
-- [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
-- [Together AI](https://docs.together.ai/docs/openai-api-compatibility)
-- [Anyscale Endpoints](https://docs.anyscale.com/endpoints/intro/)
-- [Fireworks AI](https://readme.fireworks.ai/docs/openai-compatibility)
+Alternatively, you can also use **any OpenAI-compatible endpoint** by prefixing the model name with `openai/` using the `--alt-base-url` and `--alt-api-key` flags to point to the server.
+
+Instructions for for popular providers:
+- [Anthropic](https://litellm.vercel.app/docs/providers/anthropic#api-keys)
+- [Gemini - Google AI Studio](https://litellm.vercel.app/docs/providers/gemini#sample-usage)
+- [Amazon Bedrock](https://litellm.vercel.app/docs/providers/bedrock#required-environment-variables)
+- [Ollama](https://litellm.vercel.app/docs/providers/togetherai#api-keys)
+- [Together AI](https://litellm.vercel.app/docs/providers/togetherai#api-keys)
+- [Anyscale Endpoints](https://litellm.vercel.app/docs/providers/anyscale#api-key)
+
+For other model providers, view the instructions [here](https://litellm.vercel.app/docs/providers). 
 
 ## Motivation
 

--- a/examples/routing_to_local_models.md
+++ b/examples/routing_to_local_models.md
@@ -13,7 +13,7 @@ Now, the Ollama server will be running at `http://localhost:11434/v1`.
 2. Launch RouteLLM server with the `mf` router (recommended):
 ```
 > export OPENAI_API_KEY=sk-...
-> python -m routellm.openai_server --routers mf --weak-model ollama/llama3 --config.example.yaml
+> python -m routellm.openai_server --routers mf --weak-model ollama_chat/llama3 --config.example.yaml
 INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:6060 (Press CTRL+C to quit)
 ```

--- a/examples/routing_to_local_models.md
+++ b/examples/routing_to_local_models.md
@@ -13,11 +13,11 @@ Now, the Ollama server will be running at `http://localhost:11434/v1`.
 2. Launch RouteLLM server with the `mf` router (recommended):
 ```
 > export OPENAI_API_KEY=sk-...
-> python -m routellm.openai_server --routers mf --alt-base-url http://localhost:11434/v1 --config config.example.yaml --weak-model llama3
+> python -m routellm.openai_server --routers mf --weak-model ollama/llama3 --config.example.yaml
 INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:6060 (Press CTRL+C to quit)
 ```
-The server is now listening on `http://0.0.0.0:6060`. We use the `--weak-model` flag to use Llama 3 as our weak model and the `--alt-base-url` flag to point to our local Ollama server.
+The server is now listening on `http://0.0.0.0:6060`. We use the `--weak-model` flag to use point to the Llama 3 instance that is running locally on our machine.
 
 3. Point your OpenAI client to the RouteLLM server:
 ```python
@@ -37,4 +37,6 @@ response = client.chat.completions.create(
   ]
 )
 ```
-In the [Quickstart](../README.md#quickstart) section, we calibrated the threshold to be `0.116` for `mf` so that we get approximately 50% of queries routed to GPT-4, which we set in the `model` field here. And that's it - now, our requests will be routed between GPT-4 for more difficult queries and our local Llama-3 8B model for simpler queries.
+In the [Quickstart](../README.md#quickstart) section, we calibrated the threshold to be `0.116` for `mf` so that we get approximately 50% of queries routed to GPT-4, which we set in the `model` field here.
+
+And that's it! Now, our requests will be routed between GPT-4 for more difficult queries and our local Llama-3 8B model for simpler queries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,13 @@ dependencies = [
 	'tqdm',
 	'openai',
 	'transformers',
-	'tiktoken',
-	'datasets'
+	'datasets',
+	'litellm'
 ]
 
 [project.optional-dependencies]
 serve = ["fastapi", "shortuuid", "uvicorn"]
-eval = ["matplotlib", "pandarallel", "sglang"]
+eval = ["matplotlib", "pandarallel", "sglang", 'tiktoken']
 dev = ["black", "isort", "pre-commit"]
 
 [project.urls]

--- a/routellm/evals/evaluate.py
+++ b/routellm/evals/evaluate.py
@@ -182,7 +182,9 @@ if __name__ == "__main__":
     )
     parser.add_argument("--strong-model", type=str, default="gpt-4-1106-preview")
     parser.add_argument(
-        "--weak-model", type=str, default="mistralai/Mixtral-8x7B-Instruct-v0.1"
+        "--weak-model",
+        type=str,
+        default="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
     )
     parser.add_argument("--config", type=str)
     parser.add_argument("--num-results", type=int, default=10)

--- a/routellm/openai_server.py
+++ b/routellm/openai_server.py
@@ -170,7 +170,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
 
 
 parser = argparse.ArgumentParser(
-    description="OpenAI compatible API server for LLM routing."
+    description="An OpenAI-compatible API server for LLM routing."
 )
 parser.add_argument(
     "--verbose",
@@ -188,13 +188,13 @@ parser.add_argument(
 )
 parser.add_argument(
     "--alt-base-url",
-    help="The OpenAI-compatible base URL for non-OpenAI API requests",
+    help="The base URL used for LLM requests",
     type=str,
     default=None,
 )
 parser.add_argument(
     "--alt-api-key",
-    help="The API key for non-OpenAI API requests",
+    help="The API key used for LLM requests",
     type=str,
     default=None,
 )


### PR DESCRIPTION
Integrates LiteLLM to support a wider range of model providers, including Anthropic, Amazon Bedrock, and Google AI Studio more easily.

We continue to support OpenAI-compatible endpoints using the `--alt-base-url` and `--alt-api-key` flags. To do so, prefix the model name with `openai/` and it will be treated as an OpenAI compatible endpoint.