### PR TITLE
Minor Typos in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This means that I'll want to use `0.116` as my cost threshold to get approximate
 import openai
 
 client = openai.OpenAI(
-  base_url="https://localhost:6060/v1",
+  base_url="http://localhost:6060/v1",
   # Required but ignored
   api_key="no_api_key"
 )

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Let's walkthrough setting up a RouteLLM server and pointing our existing OpenAI 
 ```
 > export OPENAI_API_KEY=sk-XXXXXX
 > export ANYSCALE_API_KEY=esecret_XXXXXX
-> python -m routellm.openai_server --routers mf --weak-model anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1 ---config config.example.yaml
+> python -m routellm.openai_server --routers mf --weak-model anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1 --config config.example.yaml
 INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:6060 (Press CTRL+C to quit)
 ```


### PR DESCRIPTION
Changed "---config" to "--config" in the first example of the main Readme