### PR TITLE
Add unified controller interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ python -m examples.router_chat --router mf --threshold 0.11593
 
 In the above examples, GPT-4 and Mixtral 8x7B are used as the model pair, but you can modify this using the `strong-model` and `weak-model` arguments.
 
-We leverage [LiteLLM](https://github.com/BerriAI/litellm) to support chat completions from a wide-range of open-source and closed models. In general, you need a setup an API key and point to the provider with the appropriate model name. Alternatively, you can also use **any OpenAI-compatible endpoint** by prefixing the model name with `openai/` using the `--alt-base-url` and `--alt-api-key` flags to point to the server.
+We leverage [LiteLLM](https://github.com/BerriAI/litellm) to support chat completions from a wide-range of open-source and closed models. In general, you need a setup an API key and point to the provider with the appropriate model name. Alternatively, you can also use **any OpenAI-compatible endpoint** by prefixing the model name with `openai/` and setting the `--base-url` and `--api-key` flags.
 
 Note that regardless of the model pair used, an `OPENAI_API_KEY` will be required to generate embeddings for both the `mf` and `sw_ranking` routers.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"
 # Replace with your model provider.
 os.environ["ANYSCALE_API_KEY"] = "esecret_XXXXXX"
 
-# No longer needed
 # client = OpenAI()
 client = Controller(
   routers=["mf"],

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"
 # Replace with your model provider.
 os.environ["ANYSCALE_API_KEY"] = "esecret_XXXXXX"
 
+# No longer needed
+# client = OpenAI()
 client = Controller(
   routers=["mf"],
   routed_pair=ModelPair(

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install -e .[serve,eval]
 
 Let's walkthrough updating our existing OpenAI client to route queries between LLMs instead of only using one model.
 
-1. First, initialize the RouteLLM controller with the `mf` router:
+1. First, let's initialize the RouteLLM controller with the `mf` router. By default, RouteLLM will use the best-performing configuration:
 ```python
 from routellm.controller import Controller
 
@@ -96,13 +96,14 @@ python -m examples.router_chat --router mf --threshold 0.11593
 
 ### Model Support
 
-By default, GPT-4 and Mixtral 8x7B are used as the model pair for serving. To modify the model pair used, set them using the `strong-model` and `weak-model` arguments or flags. However, regardless of the model pair, an `OPENAI_API_KEY` is required for generating embeddings.
+In the above examples, GPT-4 and Mixtral 8x7B are used as the model pair for routing. To modify the model pair used, set them using the `strong-model` and `weak-model` arguments.
 
 We leverage [LiteLLM](https://github.com/BerriAI/litellm) to support chat completions from a wide-range of open-source and closed models. In general, you need a setup an API key and point to the provider with the appropriate model name. Alternatively, you can also use **any OpenAI-compatible endpoint** by prefixing the model name with `openai/` using the `--alt-base-url` and `--alt-api-key` flags to point to the server.
 
-See [Routing to Local Models](examples/routing_to_local_models.md) for a walkthrough of routing to local models using Ollama.
+Note that regardless of the model pair used, an `OPENAI_API_KEY` will be required for generating embeddings for the `mf` and `sw_ranking` routers currently.
 
 Instructions for setting up your API keys for popular providers:
+- Local model with Ollama: see [this guide](examples/routing_to_local_models.md)
 - [Anthropic](https://litellm.vercel.app/docs/providers/anthropic#api-keys)
 - [Gemini - Google AI Studio](https://litellm.vercel.app/docs/providers/gemini#sample-usage)
 - [Amazon Bedrock](https://litellm.vercel.app/docs/providers/bedrock#required-environment-variables)
@@ -182,7 +183,7 @@ While these routers have been trained on the `gpt-4-1106-preview` and `mixtral-8
 
 ## Configuration
 
-The configuration for routers is specified in either the `config` argument for `Controller` or by passing in  the path for YAML file using `--config`. It is a top-level mapping from router name to the keyword arguments used for router initialization.
+The configuration for routers is specified in either the `config` argument for `Controller` or by passing in the path to a YAML file using the `--config` flag. It is a top-level mapping from router name to the keyword arguments used for router initialization.
 
 An example configuration is provided in the `config.example.yaml` file - it provides the configurations for routers that have trained on Arena data augmented using GPT-4 as a judge. The models and datasets used are all hosted on Hugging Face under the [RouteLLM](https://huggingface.co/routellm) and [LMSYS](https://huggingface.co/lmsys) organizations.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install -e .[serve,eval]
 
 Let's walkthrough updating our existing OpenAI client to route queries between LLMs instead of only using one model.
 
-1. First, let's initialize the RouteLLM controller with the `mf` router. By default, RouteLLM will use the best-performing configuration:
+1. First, let's initialize the RouteLLM controller with the `mf` router. By default, RouteLLM will use the best-performing config:
 ```python
 from routellm.controller import Controller
 
@@ -64,7 +64,7 @@ This means that we want to use `0.11593` as the cost threshold to get approximat
 3. Now, let's update the `model` field in our OpenAI client, specifying the router and cost threshold to use:
 ```python
 response = client.chat.completions.create(
-  # Use the MF router with a cost threshold of 0.11593
+  # This tells RouteLLM to use the MF router with a cost threshold of 0.11593
   model="router-mf-0.11593",
   messages=[
     {"role": "user", "content": "Hello!"}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Let's walkthrough replacing an existing OpenAI client to route queries between L
 
 1. First, initialize the RouteLLM controller with the `mf` router. By default, RouteLLM will use the best-performing config:
 ```python
+import os
 from routellm.controller import Controller
 
 os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:6060 (Press CTRL+C to quit)
 ```
 
-Once the server is launched, you can also launch a local router chatbot to experiment with how different messages are routed.
+Once the server is launched, you can host a local router chatbot to see how different messages are routed.
 ```
 python -m examples.router_chat --router mf --threshold 0.11593
 ```
@@ -97,11 +97,11 @@ python -m examples.router_chat --router mf --threshold 0.11593
 
 ### Model Support
 
-In the above examples, GPT-4 and Mixtral 8x7B are used as the model pair for routing. To modify the model pair used, set them using the `strong-model` and `weak-model` arguments.
+In the above examples, GPT-4 and Mixtral 8x7B are used as the model pair, but you can modify this using the `strong-model` and `weak-model` arguments.
 
 We leverage [LiteLLM](https://github.com/BerriAI/litellm) to support chat completions from a wide-range of open-source and closed models. In general, you need a setup an API key and point to the provider with the appropriate model name. Alternatively, you can also use **any OpenAI-compatible endpoint** by prefixing the model name with `openai/` using the `--alt-base-url` and `--alt-api-key` flags to point to the server.
 
-Note that regardless of the model pair used, an `OPENAI_API_KEY` will be required for generating embeddings for the `mf` and `sw_ranking` routers currently.
+Note that regardless of the model pair used, an `OPENAI_API_KEY` will be required to generate embeddings for both the `mf` and `sw_ranking` routers.
 
 Instructions for setting up your API keys for popular providers:
 - Local model with Ollama: see [this guide](examples/routing_to_local_models.md)

--- a/README.md
+++ b/README.md
@@ -43,11 +43,9 @@ os.environ["ANYSCALE_API_KEY"] = "esecret_XXXXXX"
 # client = OpenAI()
 client = Controller(
   routers=["mf"],
-  routed_pair=ModelPair(
-      strong="gpt-4-1106-preview",
-      # Mixtral 8x7B model provided by Anyscale
-      weak="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
-  ),
+  strong_model="gpt-4-1106-preview",
+  # Mixtral 8x7B model provided by Anyscale
+  weak_model="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
 )
 ```
 Above, we pick `gpt-4-1106-preview` as the strong model and `anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1` as the weak model, setting the API keys accordingly. You can route between different model pairs or providers by updating the model names as described in [Model Support](#model-support).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,13 +5,9 @@ sw_ranking:
     arena_embedding_datasets:
       - routellm/arena_battles_embeddings
       - routellm/gpt4_judge_battles_embeddings
-    strong_model: gpt-4-1106-preview
-    weak_model: mixtral-8x7b-instruct-v0.1
 causal_llm:
     checkpoint_path: routellm/causal_llm_gpt4_augmented
 bert:
     checkpoint_path: routellm/bert_gpt4_augmented
 mf:
     checkpoint_path: routellm/mf_gpt4_augmented
-    strong_model: gpt-4-1106-preview
-    weak_model: mixtral-8x7b-instruct-v0.1

--- a/examples/python_sdk.md
+++ b/examples/python_sdk.md
@@ -1,0 +1,65 @@
+# RouteLLM Python SDK
+
+You can interface with RouteLLM in Python via the `Controller` class.
+
+```python
+import os
+from routellm.controller import Controller
+
+os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"
+os.environ["ANYSCALE_API_KEY"] = "esecret_XXXXXX"
+
+client = Controller(
+  # List of routers to initialize
+  routers=["mf"],
+  # The pair of strong and weak models to route to
+  strong_model="gpt-4-1106-preview",
+  weak_model="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
+  # The config for the router (best-performing config by default)
+  config = {
+    "mf": {
+      "checkpoint_path": "routellm/mf_gpt4_augmented"
+    }
+  },
+  # Override API base and key for LLM calls
+  api_base=None,
+  api_key=None,
+  # Display a progress bar for operations
+  progress_bar=False,
+)
+```
+
+The controller is a drop-in replacement for OpenAI's client and supports the same chat completions interface. You can call `acreate` for the async equivalent.
+
+```python
+response = client.chat.completions.create(
+  # This tells RouteLLM to use the MF router with a cost threshold of 0.11593
+  model="router-mf-0.11593",
+  messages=[
+    {"role": "user", "content": "Hello!"}
+  ]
+)
+print(response.choices[0]["message"]["content"])
+```
+You can also access these methods at `controller.completion` and `controller.acompletion`.
+
+
+In addition, the controller also supports a `route` method that returns the best model for a given prompt.
+```python
+routed_model = client.route(
+	prompt="What's the squareroot of 144?",
+	router="mf",
+	threshold=0.11593,
+)
+print(f"Prompt should be routed to {routed_model}")
+```
+
+Finally, the controller also supports a `batch_calculate_win_rate` method that takes in a `Series` of prompts and return the of win rate for the strong model on each prompt as calculated by the specified router. This is mainly used for offline evaluations and will parallelize operations wherever possible.
+```python
+import pandas as pd
+
+prompts = pd.Series(["What's the squareroot of 144?", "Who's the last president of the US?", "Is the sun a star?"])
+win_rates = client.batch_calculate_win_rate(prompts=prompts, router="mf")
+
+print(f"Calculated win rate for prompts:\n{win_rates.describe()}")
+```

--- a/examples/routing_to_local_models.md
+++ b/examples/routing_to_local_models.md
@@ -10,11 +10,11 @@ ollama run llama3
 ```
 Now, the Ollama server will be running at `http://localhost:11434/v1`.
 
-Next, you have 2 options depending on your use case: either replacing an existing OpenAI client in your Python code, or launching an OpenAI-compatible server.
+Next, you have 2 options depending on your use case: either replace the OpenAI client in your Python code, or launch an OpenAI-compatible server.
 
 ## Option A: Replace existing OpenAI client
 
-2. Create a RouteLLM controller with the `mf` router, specifying the local Llama 3 8B model as the weak model:
+2. Create a RouteLLM controller with the `mf` router, specifying the local Llama 3 8B as the weak model:
 ```python
 os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"
 
@@ -27,10 +27,9 @@ client = Controller(
 )
 ```
 
-3. Update the `model` field in your existing OpenAI client code:
+3. Update the `model` field in when generating completions:
 ```python
 response = client.chat.completions.create(
-  # Use the MF router with a threshold of 0.116
   model="router-mf-0.11593",
   messages=[
     {"role": "user", "content": "Hello!"}
@@ -43,14 +42,14 @@ And that's it! Now, our requests will be routed between GPT-4 for more difficult
 
 ## Option B: Launch an OpenAI-compatible Server
 
-2. Launch an OpenAI-compatible with the `mf` router:
+2. Launch a server with the `mf` router:
 ```
 > export OPENAI_API_KEY=sk-...
 > python -m routellm.openai_server --routers mf --weak-model ollama_chat/llama3 --config.example.yaml
 INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:6060 (Press CTRL+C to quit)
 ```
-The server is now listening on `http://0.0.0.0:6060`. We use the `--weak-model` flag to use point to the Llama 3 instance that is running locally on our machine.
+The server is now listening on `http://0.0.0.0:6060`. We use the `--weak-model` flag to use point to the Llama 3 model that is running locally on our machine.
 
 3. Point your OpenAI client to the RouteLLM server:
 ```python
@@ -62,7 +61,6 @@ client = openai.OpenAI(
 )
 ...
 response = client.chat.completions.create(
-  # Use the MF router with a threshold of 0.11593
   model="router-mf-0.11593",
   messages=[
     {"role": "user", "content": "Hello!"}

--- a/examples/routing_to_local_models.md
+++ b/examples/routing_to_local_models.md
@@ -20,10 +20,8 @@ os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"
 
 client = Controller(
   routers=["mf"],
-  routed_pair=ModelPair(
-      strong="gpt-4-1106-preview",
-      weak="ollama_chat/llama3",
-  ),
+  strong_model="gpt-4-1106-preview",
+  weak_model="ollama_chat/llama3",
 )
 ```
 

--- a/routellm/calibrate_threshold.py
+++ b/routellm/calibrate_threshold.py
@@ -56,5 +56,5 @@ if __name__ == "__main__":
         for router in args.routers:
             threshold = thresholds_df[router].quantile(q=1 - args.strong_model_pct)
             print(
-                f"For {args.strong_model_pct * 100}% strong model calls for {router}: threshold = {round(threshold, 5)}"
+                f"For {args.strong_model_pct * 100}% strong model calls for {router}, threshold = {round(threshold, 5)}"
             )

--- a/routellm/calibrate_threshold.py
+++ b/routellm/calibrate_threshold.py
@@ -9,8 +9,6 @@ from tqdm import tqdm
 from routellm.controller import Controller
 from routellm.routers.routers import ROUTER_CLS
 
-tqdm.pandas()
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/routellm/controller.py
+++ b/routellm/controller.py
@@ -1,0 +1,96 @@
+from collections import defaultdict
+from types import SimpleNamespace
+from typing import Any
+
+import tqdm
+from litellm import acompletion, completion
+
+from routellm.model_pair import ModelPair
+from routellm.routers.routers import ROUTER_CLS
+
+
+class RoutingError(Exception):
+    pass
+
+
+class Controller:
+    def __init__(
+        self,
+        routers: list[str],
+        config: dict[str, dict[str, Any]],
+        routed_pair: ModelPair,
+        api_base: str = None,
+        api_key: str = None,
+        progress_bar: bool = False,
+    ):
+        self.routed_pair = routed_pair
+        self.routers = {}
+        self.api_base = api_base
+        self.api_key = api_key
+
+        self.model_counts = defaultdict(lambda: defaultdict(int))
+
+        router_pbar = tqdm.tqdm(routers) if progress_bar else None
+        for router in routers:
+            if router_pbar is not None:
+                router_pbar.set_description(f"Loading {router}")
+            self.routers[router] = ROUTER_CLS[router](**config.get(router, {}))
+
+        # Some Python magic to match the OpenAI Python SDK
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=self.completion, acreate=self.acompletion
+            )
+        )
+
+    def _validate(self, router: str, threshold: float):
+        if router not in self.routers:
+            raise RoutingError(
+                f"Invalid router {router}. Available routers are {list(self.routers.keys())}."
+            )
+        elif not isinstance(threshold, float) or not 0 <= threshold <= 1:
+            raise RoutingError(
+                f"Invalid threshold {threshold}. Threshold must be a float between 0.0 and 1.0."
+            )
+
+    def _get_routed_model_for_completion(self, kwargs: dict[str, Any]):
+        if "messages" not in kwargs or not kwargs["messages"]:
+            raise ValueError("messages must be a non-empty list")
+
+        model = kwargs["model"]
+        _, router, threshold = model.split("-", 2)
+        try:
+            threshold = float(threshold)
+        except ValueError as e:
+            raise RoutingError(f"Threshold {threshold} must be a float.") from e
+        if not model.startswith("router"):
+            raise RoutingError(
+                f"Invalid model {model}. Model name must be of the format 'router-[router name]-[threshold]."
+            )
+        self._validate(router, float(threshold))
+
+        # Look at the last turn for routing.
+        # Our current routers were only trained on first turn data, so more research is required here.
+        prompt = kwargs["messages"][-1]["content"]
+        routed_model = self.routers[router].route(prompt, threshold, self.routed_pair)
+
+        self.model_counts[router][routed_model] += 1
+
+        return routed_model
+
+    def route(self, prompt: str, router: str, threshold: float):
+        self._validate(router, threshold)
+
+        return self.routers[router].route(prompt, threshold, self.routed_pair)
+
+    # Matches OpenAI's Chat Completions interface
+    def completion(self, **kwargs):
+        routed_model = self._get_routed_model_for_completion(kwargs)
+        kwargs["model"] = routed_model
+        return completion(api_base=self.api_base, api_key=self.api_key, **kwargs)
+
+    # Matches OpenAI's Async Chat Completions interface
+    async def acompletion(self, **kwargs):
+        routed_model = self._get_routed_model_for_completion(kwargs)
+        kwargs["model"] = routed_model
+        return await acompletion(api_base=self.api_base, api_key=self.api_key, **kwargs)

--- a/routellm/controller.py
+++ b/routellm/controller.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from types import SimpleNamespace
 from typing import Any, Optional
 
+import pandas as pd
 import tqdm
 from litellm import acompletion, completion
 
@@ -80,6 +81,19 @@ class Controller:
         self.model_counts[router][routed_model] += 1
 
         return routed_model
+
+    # Mainly used for evaluations
+    def batch_calculate_win_rate(
+        self,
+        prompts: pd.Series,
+        router: str,
+    ):
+        self._validate_router_threshold(router, 0)
+        router_instance = self.routers[router]
+        if router_instance.NO_PARALLEL:
+            return prompts.progress_apply(router_instance.calculate_strong_win_rate)
+        else:
+            return prompts.parallel_apply(router_instance.calculate_strong_win_rate)
 
     def route(self, prompt: str, router: str, threshold: float):
         self._validate_router_threshold(router, threshold)

--- a/routellm/evals/benchmarks.py
+++ b/routellm/evals/benchmarks.py
@@ -12,7 +12,6 @@ from routellm.routers.routers import Router
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 pd.options.mode.copy_on_write = True
-tqdm.pandas()
 
 
 class Benchmark(abc.ABC):

--- a/routellm/evals/evaluate.py
+++ b/routellm/evals/evaluate.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
             router_results = []
             for i in range(args.random_iters):
                 for threshold, accuracy, model_counts, total in benchmark.evaluate(
-                    controller.routers[router], args.num_results, True
+                    controller, router, args.num_results, True
                 ):
                     router_results.append(
                         {
@@ -246,7 +246,7 @@ if __name__ == "__main__":
         else:
             router_results = []
             for threshold, accuracy, model_counts, total in benchmark.evaluate(
-                controller.routers[router], args.num_results, False
+                controller, router, args.num_results, False
             ):
                 print(f"Evaluating router: {router} with threshold {threshold}...")
                 pretty_print_results(threshold, accuracy, model_counts, total)

--- a/routellm/evals/evaluate.py
+++ b/routellm/evals/evaluate.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
         type=str,
         default="mistralai/Mixtral-8x7B-Instruct-v0.1",
     )
-    parser.add_argument("--config", type=str)
+    parser.add_argument("--config", type=str, default=None)
     parser.add_argument("--num-results", type=int, default=10)
     parser.add_argument("--random-iters", type=int, default=10)
 
@@ -197,9 +197,9 @@ if __name__ == "__main__":
     pandarallel.initialize(progress_bar=True, nb_workers=args.parallel)
     routed_pair = ModelPair(strong=args.strong_model, weak=args.weak_model)
     controller = Controller(
-        args.routers,
-        yaml.safe_load(open(args.config, "r")),
-        routed_pair,
+        routers=args.routers,
+        config=yaml.safe_load(open(args.config, "r")) if args.config else None,
+        routed_pair=routed_pair,
         progress_bar=True,
     )
 

--- a/routellm/evals/gsm8k/generate_responses.py
+++ b/routellm/evals/gsm8k/generate_responses.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from openai import OpenAI
 
-from routellm.model_pair import ModelPair
+from routellm.controller import ModelPair
 
 """
 The core code is based heavily on the original SGLang implementation.

--- a/routellm/evals/mmlu/generate_responses.py
+++ b/routellm/evals/mmlu/generate_responses.py
@@ -10,8 +10,8 @@ import tiktoken
 import tqdm
 from openai import OpenAI
 
+from routellm.controller import ModelPair
 from routellm.evals.mmlu.domains import ALL_MMLU_DOMAINS
-from routellm.model_pair import ModelPair
 
 ROUTED_PAIR = ModelPair(
     strong="gpt-4-1106-preview", weak="mistralai/Mixtral-8x7B-Instruct-v0.1"

--- a/routellm/model_pair.py
+++ b/routellm/model_pair.py
@@ -1,7 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class ModelPair:
-    strong: str
-    weak: str

--- a/routellm/openai_server.py
+++ b/routellm/openai_server.py
@@ -39,8 +39,8 @@ async def lifespan(app):
         routers=args.routers,
         config=yaml.safe_load(open(args.config, "r")) if args.config else None,
         routed_pair=routed_pair,
-        alt_base_url=args.alt_base_url,
-        alt_api_key=args.alt_api_key,
+        api_base=args.base_url,
+        api_key=args.api_key,
         progress_bar=True,
     )
     yield
@@ -159,14 +159,14 @@ parser.add_argument(
     choices=list(ROUTER_CLS.keys()),
 )
 parser.add_argument(
-    "--alt-base-url",
-    help="The base URL used for LLM requests",
+    "--base-url",
+    help="The base URL used for all LLM requests",
     type=str,
     default=None,
 )
 parser.add_argument(
-    "--alt-api-key",
-    help="The API key used for LLM requests",
+    "--api-key",
+    help="The API key used for all LLM requests",
     type=str,
     default=None,
 )

--- a/routellm/openai_server.py
+++ b/routellm/openai_server.py
@@ -20,7 +20,6 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
 from routellm.controller import Controller, RoutingError
-from routellm.model_pair import ModelPair
 from routellm.routers.routers import ROUTER_CLS
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -34,11 +33,11 @@ count = defaultdict(lambda: defaultdict(int))
 async def lifespan(app):
     global CONTROLLER
 
-    routed_pair = ModelPair(strong=args.strong_model, weak=args.weak_model)
     CONTROLLER = Controller(
         routers=args.routers,
         config=yaml.safe_load(open(args.config, "r")) if args.config else None,
-        routed_pair=routed_pair,
+        strong_model=args.strong_model,
+        weak_model=args.weak_model,
         api_base=args.base_url,
         api_key=args.api_key,
         progress_bar=True,

--- a/routellm/openai_server.py
+++ b/routellm/openai_server.py
@@ -4,7 +4,6 @@ It current only supports Chat Completions: https://platform.openai.com/docs/api-
 """
 
 import argparse
-import asyncio
 import logging
 import os
 import time
@@ -13,20 +12,19 @@ from typing import AsyncGenerator, Dict, List, Literal, Optional, Union
 
 import fastapi
 import shortuuid
-import tqdm
 import uvicorn
 import yaml
 from fastapi.concurrency import asynccontextmanager
 from fastapi.responses import JSONResponse, StreamingResponse
-from litellm import acompletion
 from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
+from routellm.controller import Controller, RoutingError
 from routellm.model_pair import ModelPair
 from routellm.routers.routers import ROUTER_CLS
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
-ROUTERS_MAP = {}
+CONTROLLER = None
 
 openai_client = AsyncOpenAI()
 count = defaultdict(lambda: defaultdict(int))
@@ -34,13 +32,19 @@ count = defaultdict(lambda: defaultdict(int))
 
 @asynccontextmanager
 async def lifespan(app):
-    router_pbar = tqdm.tqdm(args.routers)
-    for router in router_pbar:
-        router_pbar.set_description(f"Loading {router}")
-        router_config = config.get(router, {})
-        ROUTERS_MAP[router] = ROUTER_CLS[router](**router_config)
+    global CONTROLLER
+
+    routed_pair = ModelPair(strong=args.strong_model, weak=args.weak_model)
+    CONTROLLER = Controller(
+        args.routers,
+        yaml.safe_load(open(args.config, "r")),
+        routed_pair,
+        args.alt_base_url,
+        args.alt_api_key,
+        progress_bar=True,
+    )
     yield
-    ROUTERS_MAP.clear()
+    CONTROLLER = None
 
 
 app = fastapi.FastAPI(lifespan=lifespan)
@@ -116,57 +120,25 @@ async def create_chat_completion(request: ChatCompletionRequest):
     # The model name field contains the parameters for routing.
     # Model name uses format router-[router name]-[threshold] e.g. router-bert-0.7
     # The router type and threshold is used for routing that specific request.
-    _, router, threshold = request.model.split("-", 2)
-    logging.info(f"Received request for router {router} and threshold {threshold}")
-    if not request.model.startswith("router"):
-        return JSONResponse(
-            ErrorResponse(
-                message=f"Invalid model {request.model}. Model name must be of the format 'router-[router name]-[threshold]'."
-            ).model_dump(),
-            status_code=400,
+    logging.info(f"Received request: {request}")
+    try:
+        res = await CONTROLLER.acompletion(
+            **request.model_dump(exclude_none=True),
         )
-    elif router not in ROUTERS_MAP:
+    except RoutingError as e:
         return JSONResponse(
-            ErrorResponse(
-                message=f"Invalid router {router}. Available routers are {list(ROUTERS_MAP.keys())}."
-            ).model_dump(),
-            status_code=400,
-        )
-    elif not 0.0 <= float(threshold) <= 1.0:
-        return JSONResponse(
-            ErrorResponse(
-                message=f"Invalid threshold {threshold}. Threshold must be a float between 0.0 and 1.0."
-            ).model_dump(),
+            ErrorResponse(message=str(e)).model_dump(),
             status_code=400,
         )
 
-    threshold = float(threshold)
-
-    # Look at the last turn for routing.
-    # Our current routers were only trained on first turn data, so more research is required here.
-    prompt = request.messages[-1]["content"]
-
-    route_fn = ROUTERS_MAP[router].route
-    if asyncio.iscoroutinefunction(route_fn):
-        routed_model = await route_fn(prompt, threshold, ROUTED_PAIR)
-    else:
-        routed_model = route_fn(prompt, threshold, ROUTED_PAIR)
-    count[router][routed_model] += 1
-    logging.info(f"Model Counts: {dict(count)}")
-
-    generator = await acompletion(
-        model=routed_model,
-        api_base=API_BASE,
-        api_key=API_KEY,
-        **request.model_dump(exclude=["model"], exclude_none=True),
-    )
+    logging.info(CONTROLLER.model_counts)
 
     if request.stream:
         return StreamingResponse(
-            content=stream_response(generator), media_type="text/event-stream"
+            content=stream_response(res), media_type="text/event-stream"
         )
     else:
-        return JSONResponse(content=generator.model_dump())
+        return JSONResponse(content=res.model_dump())
 
 
 parser = argparse.ArgumentParser(
@@ -203,17 +175,6 @@ parser.add_argument(
     "--weak-model", type=str, default="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1"
 )
 args = parser.parse_args()
-
-config = yaml.safe_load(open(args.config, "r"))
-
-alt_client = AsyncOpenAI(
-    base_url=args.alt_base_url,
-    api_key=args.alt_api_key,
-)
-
-ROUTED_PAIR = ModelPair(strong=args.strong_model, weak=args.weak_model)
-API_BASE = args.alt_base_url
-API_KEY = args.alt_api_key
 
 if args.verbose:
     logging.basicConfig(level=logging.INFO)

--- a/routellm/openai_server.py
+++ b/routellm/openai_server.py
@@ -36,11 +36,11 @@ async def lifespan(app):
 
     routed_pair = ModelPair(strong=args.strong_model, weak=args.weak_model)
     CONTROLLER = Controller(
-        args.routers,
-        yaml.safe_load(open(args.config, "r")),
-        routed_pair,
-        args.alt_base_url,
-        args.alt_api_key,
+        routers=args.routers,
+        config=yaml.safe_load(open(args.config, "r")) if args.config else None,
+        routed_pair=routed_pair,
+        alt_base_url=args.alt_base_url,
+        alt_api_key=args.alt_api_key,
         progress_bar=True,
     )
     yield
@@ -149,7 +149,7 @@ parser.add_argument(
     action="store_true",
 )
 parser.add_argument("--workers", type=int, default=0)
-parser.add_argument("--config", type=str)
+parser.add_argument("--config", type=str, default=None)
 parser.add_argument("--port", type=int, default=6060)
 parser.add_argument(
     "--routers",

--- a/routellm/routers/routers.py
+++ b/routellm/routers/routers.py
@@ -135,8 +135,10 @@ class SWRankingRouter(Router):
         self,
         arena_battle_datasets,
         arena_embedding_datasets,
-        strong_model,
-        weak_model,
+        # This is the model pair for Elo calculations at inference time,
+        # and can be different from the model pair used for routing.
+        strong_model="gpt-4-1106-preview",
+        weak_model="mixtral-8x7b-instruct-v0.1",
         num_tiers=10,
     ):
         self.strong_model = strong_model
@@ -209,8 +211,10 @@ class MatrixFactorizationRouter(Router):
     def __init__(
         self,
         checkpoint_path,
-        strong_model,
-        weak_model,
+        # This is the model pair for scoring at inference time,
+        # and can be different from the model pair used for routing.
+        strong_model="gpt-4-1106-preview",
+        weak_model="mixtral-8x7b-instruct-v0.1",
         hidden_size=128,
         num_models=64,
         text_dim=1536,

--- a/routellm/tests/test_openai_client.py
+++ b/routellm/tests/test_openai_client.py
@@ -1,0 +1,58 @@
+import argparse
+
+from routellm.controller import Controller
+from routellm.model_pair import ModelPair
+from routellm.routers.routers import ROUTER_CLS
+
+system_content = (
+    "You are a helpful assistant. Respond to the questions as best as you can."
+)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--router",
+        type=str,
+        default="random",
+        choices=ROUTER_CLS.keys(),
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.7,
+        help="Threshold for the router",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="What is heavier, a pound of feathers or a kilogram of steel?",
+    )
+    args = parser.parse_args()
+    print(args)
+
+    client = Controller(
+        routers=["mf"],
+        config={
+            "mf": {
+                "checkpoint_path": "routellm/mf_gpt4_augmented",
+            }
+        },
+        routed_pair=ModelPair(
+            strong="gpt-4-1106-preview",
+            weak="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
+        ),
+    )
+
+    chat_completion = client.chat.completions.create(
+        # Or, you can specify these in the model e.g. f"router-{args.router}-{args.threshold}"
+        router=args.router,
+        threshold=args.threshold,
+        messages=[
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": args.prompt},
+        ],
+        temperature=0.7,
+    )
+
+    response = chat_completion.choices[0].message.content
+    print(f"Router used {chat_completion.model} and received: {response}")

--- a/routellm/tests/test_openai_client.py
+++ b/routellm/tests/test_openai_client.py
@@ -1,7 +1,10 @@
 import argparse
+import os
 
 from routellm.controller import Controller
 from routellm.routers.routers import ROUTER_CLS
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 system_content = (
     "You are a helpful assistant. Respond to the questions as best as you can."

--- a/routellm/tests/test_openai_client.py
+++ b/routellm/tests/test_openai_client.py
@@ -31,12 +31,7 @@ if __name__ == "__main__":
     print(args)
 
     client = Controller(
-        routers=["mf"],
-        config={
-            "mf": {
-                "checkpoint_path": "routellm/mf_gpt4_augmented",
-            }
-        },
+        routers=[args.router],
         routed_pair=ModelPair(
             strong="gpt-4-1106-preview",
             weak="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",

--- a/routellm/tests/test_openai_client.py
+++ b/routellm/tests/test_openai_client.py
@@ -1,7 +1,6 @@
 import argparse
 
 from routellm.controller import Controller
-from routellm.model_pair import ModelPair
 from routellm.routers.routers import ROUTER_CLS
 
 system_content = (
@@ -32,10 +31,8 @@ if __name__ == "__main__":
 
     client = Controller(
         routers=[args.router],
-        routed_pair=ModelPair(
-            strong="gpt-4-1106-preview",
-            weak="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
-        ),
+        strong_model="gpt-4-1106-preview",
+        weak_model="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
     )
 
     chat_completion = client.chat.completions.create(


### PR DESCRIPTION
Introduces a `Controller` interface for RouteLLM that allows it to be used as a Python SDK without having to launch a server. The controller can act as a drop-in replacement for the OpenAI client and has parity with the server API.

```python
from routellm.controller import Controller

# Replace OpenAI client with Controller
# client = OpenAI() 
client = Controller(
  # By default, Controller uses the best performing configuration.
  routers=["mf"],
  strong_model="gpt-4-1106-preview",
  weak_model="anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
)

client.chat.completions.create(
    # Or, you can specify the router and threshold directly as keyword arguments.
    model="router-mf-0.116"
    messages=[
        {"role": "user", "content": "Hello!"},
    ],
)
```

The controller also supports returning the model name to route to for a given prompt.
```python
routed_model = controller.route(prompt="What's the square root of 144?", router="mf", threshold=0.116)
```

The server and evaluation framework now use `Controller` to manage their routers through a unified interface!

TODO:
- [ ] Update docs