### PR TITLE
Fixing UnsupportedParamsError in `litellm` when using `groq` model with OpenAI

### DIFF
--- a/routellm/controller.py
+++ b/routellm/controller.py
@@ -3,6 +3,11 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Optional
 
+#LiteLLM maps all supported openai params by provider + model (e.g. function calling is supported by OpenAI but not Groq).
+#If a provider/model doesn't support a particular param, we can drop it.
+import litellm
+litellm.drop_params = True
+
 import pandas as pd
 from litellm import acompletion, completion
 from tqdm import tqdm


### PR DESCRIPTION
Dear Maintainers,

I encountered an issue when running the command:

```bash
python -m routellm.openai_server --routers mf --strong-model openai/gpt4o --weak-model groq/llama3-8b-8192
```

The error message indicated that the `groq` model does not support certain parameters:

``` python
litellm.UnsupportedParamsError: groq does not support parameters: {'presence_penalty': 0.0, 'frequency_penalty': 0.0}, for model=llama3-8b-8192.
```

To resolve this, I added the following command to set `drop_params` to `True`:

```python
import litellm
litellm.drop_params = True
```

This change successfully addresses the issue by ensuring that unsupported parameters are dropped, allowing the command to execute without errors.

I would like to submit these changes for review and merge into the main branch. Please let me know if you need any further information or modifications.

Thanks!