### PR TITLE
fix: set litellm.drop_params to support non-OpenAI providers (#63)

### DIFF
--- a/routellm/controller.py
+++ b/routellm/controller.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 from typing import Any, Optional
 
 import pandas as pd
+import litellm
 from litellm import acompletion, completion
+
+litellm.drop_params = True
 from tqdm import tqdm
 
 from routellm.routers.routers import ROUTER_CLS


### PR DESCRIPTION
## Summary

Fixes #63. Also addresses the issue described in #32.

## Problem

When using non-OpenAI providers (Ollama, Groq, local models) as the weak model, litellm raises `UnsupportedParamsError` because parameters like `presence_penalty` and `frequency_penalty` are not supported by all providers.

The `ChatCompletionRequest` in `openai_server.py` defaults these to `0.0`, and `model_dump(exclude_none=True)` always includes them since they're not `None`. When litellm forwards these to providers that don't support them, it crashes.

## Solution

Set `litellm.drop_params = True` at module level in `controller.py`. This is litellm's built-in mechanism for handling provider compatibility — unsupported parameters are silently dropped rather than raising errors.

This enables RouteLLM to work seamlessly with any provider supported by litellm (Ollama, Groq, Together AI, local models, etc.) without requiring users to manually configure parameter handling.

## Changes

- `routellm/controller.py`: Added `import litellm` and set `litellm.drop_params = True`

## Testing

- Verified `drop_params` flag is set on module load
- Tested with Ollama as weak model — no more `UnsupportedParamsError`
- No impact on OpenAI/Anyscale providers (they already support these params)
